### PR TITLE
[BL-27] - Add Orderings on lists and tasks with migration

### DIFF
--- a/src/hooks/useTaskListState.ts
+++ b/src/hooks/useTaskListState.ts
@@ -162,7 +162,6 @@ export const useTaskListState = () => {
 
     const newTask: ITask = {
       ...querieResult.data.createTask,
-      order: taskListObjective.tasks.length + 1,
     };
 
     const taskListsEdited: ITaskListState[] = JSON.parse(


### PR DESCRIPTION
* Get task order from server instead of creating it local